### PR TITLE
Use a site's public setting for determining whether to require login

### DIFF
--- a/docs/require-login.md
+++ b/docs/require-login.md
@@ -2,17 +2,13 @@
 
 By default, all websites are publicly accessible. In some situations, you may want to require users to be logged in to access the website. This is especially useful when in pre-launch mode.
 
-## Multisite Environments
+## Controlling Site Access
 
-In a multisite environment, requiring login is as easy as unchecking the site's public setting in the Edit Site screen. To access this setting, go to My Sites > Network Admin > Sites > Click the URL for the site you want to edit > Attributes > Public.
-
-## Single Site Environments
-
-Single site environments running in Cloud that are not of type `production` have the `require-login` feature enabled by default.
+Requiring login on individual sites is as easy as unchecking the site's public setting in the Edit Site screen. To access this setting, go to [My Sites > Network Admin > Sites](internal://network-admin/sites.php) and then click the URL for the site you want to edit. From there you check the box for whether the site is public or not under the "Attributes" section.
 
 ## Overrides
 
-You can also set the `security.require-login` setting to `true` in `composer.json` to require all users to be logged in to view the website (this will override individual sites' public setting in a multisite environment). If you want to make a non-production single site environment public, set the `altis.environments.${ environment-name }.modules.security.require-login` setting to `false`, as shown below.
+You can also set the `security.require-login` setting to `true` in `composer.json` to require all users to be logged in to view the website (this will override individual sites' public setting). You can require login for all environments by adding the setting directly under `altis.modules`, or individual environments by nesting it within `altis.environments`. The following example sets all environments except for local to require login:
 
 ```json
 "altis": {

--- a/docs/require-login.md
+++ b/docs/require-login.md
@@ -1,8 +1,18 @@
 # Require Login
 
-By default, all websites are publicly accessible. In some situations, you may want to require users be logged in to access the website. This is especially useful when in pre-launch mode.
+By default, all websites are publicly accessible. In some situations, you may want to require users to be logged in to access the website. This is especially useful when in pre-launch mode.
 
-Environments running in Cloud that are not of type `production` have the `require-login` feature enabled by default. Set the `security.require-login` setting to `true` to require all users be logged in to view the website. If you want to make a non-production site public, set the `altis.environments.${ environment-name }.modules.security.require-login` setting to `false`.
+## Multisite Environments
+
+In a multisite environment, requiring login is as easy as unchecking the site's public setting in the Edit Site screen. To access this setting, go to My Sites > Network Admin > Sites > Click the URL for the site you want to edit > Attributes > Public.
+
+## Single Site Environments
+
+Single site environments running in Cloud that are not of type `production` have the `require-login` feature enabled by default.
+
+## Overrides
+
+You can also set the `security.require-login` setting to `true` in `composer.json` to require all users to be logged in to view the website (this will override individual sites' public setting in a multisite environment). If you want to make a non-production single site environment public, set the `altis.environments.${ environment-name }.modules.security.require-login` setting to `false`, as shown below.
 
 ```json
 "altis": {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -47,17 +47,8 @@ function is_site_public() : bool {
 		return false;
 	}
 
-	// If this is a multisite installation, return whether the site is set to public.
-	if ( is_multisite() ) {
-		return get_site()->public;
-	}
-
-	// For single site installations, set defaults based on environment.
-	if ( in_array( get_environment_type(), [ 'production', 'local' ], true ) ) {
-		return true;
-	}
-
-	return false;
+	// If there are no overrides, return whether the site is set to public.
+	return get_site()->public;
 }
 
 /**

--- a/load.php
+++ b/load.php
@@ -2,7 +2,6 @@
 
 namespace Altis\Security; // @codingStandardsIgnoreLine
 
-use function Altis\get_environment_type;
 use function Altis\register_module;
 
 require_once __DIR__ . '/inc/namespace.php';
@@ -16,7 +15,7 @@ if ( ! function_exists( 'add_action' ) ) {
 add_action( 'altis.modules.init', function () {
 	$default_settings = [
 		'enabled'                   => true,
-		'require-login'             => ! in_array( get_environment_type(), [ 'production', 'local' ], true ),
+		'require-login'             => false,
 		'audit-log'                 => true,
 		'2-factor-authentication'   => true,
 		'minimum-password-strength' => 2,


### PR DESCRIPTION
* Set require-login to false by default
* Add is_site_public conditional function to:
  * Allow network-wide overrides from composer.json first
  * If it's a multisite installation, use the site's public setting
  * For single site installations, set defaults based on environment

Fixes #29 