### PR TITLE
Fix fatal error when site is not an instance of WP_Site

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -50,7 +50,7 @@ function is_site_public() : bool {
 	// If there are no overrides, return whether the site is set to public.
 	$site = get_site();
 
-	return $site instanceof WP_Site ? $site->public : false;
+	return get_site()->public ?? false;
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -48,7 +48,9 @@ function is_site_public() : bool {
 	}
 
 	// If there are no overrides, return whether the site is set to public.
-	return get_site()->public;
+	$site = get_site();
+
+	return $site instanceof WP_Site ? $site->public : false;
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -48,8 +48,6 @@ function is_site_public() : bool {
 	}
 
 	// If there are no overrides, return whether the site is set to public.
-	$site = get_site();
-
 	return get_site()->public ?? false;
 }
 


### PR DESCRIPTION
`Notice: Trying to get property 'public' of non-object in /chassis/packages/security/inc/namespace.php on line 51
Fatal error: Uncaught TypeError: Return value of Altis\Security\is_site_public() must be of the type boolean, null returned in /chassis/packages/security/inc/namespace.php:51`