### PR TITLE
Default site to public during install

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -40,6 +40,10 @@ function on_plugins_loaded() {
  * @return bool
  */
 function is_site_public() : bool {
+	// Allow public access during the install process.
+	if ( defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
+		return true;
+	}
 
 	// Allow overrides from composer.json.
 	$config = get_config()['modules']['security'];


### PR DESCRIPTION
This avoids the issue with MS functions not being available until after the installation process has completed.

Mitigates https://github.com/humanmade/altis-core/issues/53