### PR TITLE
Limit login attempts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
 	"autoload": {
 		"files": [
 			"inc/namespace.php",
-			"inc/passwords/namespace.php"
+			"inc/passwords/namespace.php",
+			"inc/limit_login_attempts/namespace.php"
 		],
 		"classmap": [
 			"inc/",

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,6 @@
 			"inc/stream/"
 		]
 	},
-	"repositories": [
-		{
-			"type": "vcs",
-			"url": "git@github.com:humanmade/hm-limit-login-attempts.git"
-		}
-
-	],
 	"require": {
 		"php": ">=7.1",
 		"humanmade/stream": "3.3.0",

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
 		"humanmade/stream": "3.3.0",
 		"humanmade/two-factor": "0.2",
 		"humanmade/require-login": "1.0.0",
+		"humanmade/hm-limit-login-attempts": "1.1.0",
 		"bjeavons/zxcvbn-php": "^0.4.0"
 	},
 	"extra": {

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,13 @@
 			"inc/stream/"
 		]
 	},
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "git@github.com:humanmade/hm-limit-login-attempts.git"
+		}
+
+	],
 	"require": {
 		"php": ">=7.1",
 		"humanmade/stream": "3.3.0",

--- a/docs/limit-login-attempts.md
+++ b/docs/limit-login-attempts.md
@@ -86,7 +86,7 @@ You can also disable the functionality altogether by setting `limit-login-attemp
 }
 ```
 
-If `true` provided instead of a configuration object, then the plugin will use the same defaults but are able to be overridden via the settings page in the admin under `Settings -> Limit Logins`.
+If `true` provided instead of a configuration object, then the plugin will use the same defaults but are able to be overridden via the [settings page](internal://admin/options-general.php?page=hm-limit-login-attempts) in the admin.
 
 ```json
 {

--- a/docs/limit-login-attempts.md
+++ b/docs/limit-login-attempts.md
@@ -91,7 +91,7 @@ You can also disable the functionality altogether by setting `limit-login-attemp
 }
 ```
 
-If `true` provided instead of a configuration object, then the plugin will use the same defaults but are able to be overridden via the [settings page](internal://admin/options-general.php?page=hm-limit-login-attempts) in the admin.
+If `true` provided instead of a configuration object, then the plugin will use the same defaults but they are able to be overridden via the [settings page](internal://admin/options-general.php?page=hm-limit-login-attempts) in the admin.
 
 ```json
 {

--- a/docs/limit-login-attempts.md
+++ b/docs/limit-login-attempts.md
@@ -28,7 +28,8 @@ To set the limit login attempts security settings, set values in your `composer.
 						"cookies": 1,              // Also limit malformed/forged cookies?
 						"lockout_notify": "log",   // Notify on lockout. Values: '', 'log', 'email', 'log,email'.
 						"notify_email_after": 4,   // If notify by email, do so after this number of lockouts.
-						"lockout_method": "ip"     // Method to use for lockout.
+						"lockout_method": "ip",    // Method to use for lockout.
+						"whitelisted_ips": [],     // Array of IP addresses to whitelist.
 					}
 				}
 			}
@@ -75,6 +76,10 @@ If `lockout_notify` set to either `email` or `log,email`, this setting is used t
 ### Lockout Method
 
 Setting to determine which method should be used to lock users out. Valid values are: `ip`, `username`, or `ip,username`. Defaults to `ip`.
+
+### Whitelisted IPs
+
+Setting to allow for whitelisting of IPs against the limit login functionality.
 
 ## Enable/Disable
 

--- a/docs/limit-login-attempts.md
+++ b/docs/limit-login-attempts.md
@@ -1,0 +1,12 @@
+# Limit Login Attempts
+
+To protect against brute force attacks, Altis has the ability to limit the number of login attempts possible both through normal login as well as using auth cookies.
+
+This feature blocks an IP address from making further attempts after a specified limit on retries is reached, making a brute-force attack difficult or impossible.
+
+- Limit for the number of retry attempts when logging in (for each IP).
+- Limit the number of attempts to log in using auth cookies in same way.
+- Informs user about remaining retries or lockout time on login page.
+- Optional logging, optional email notification.
+
+To disable the ability to limit the number of login attempts, set the `modules.security.limit-login-attempts` setting to `false`.

--- a/docs/limit-login-attempts.md
+++ b/docs/limit-login-attempts.md
@@ -38,7 +38,7 @@ To set the limit login attempts security settings, set values in your `composer.
 ```
 ## Configuration settings
 
-By setting the configuration settings in your `composer.json`, we lock the settings to those values and hide the admin settings page.
+By placing the configuration settings in your `composer.json`, the settings are locked to those values and the admin settings page is hidden.
 
 ### Allowed Retries
 

--- a/docs/limit-login-attempts.md
+++ b/docs/limit-login-attempts.md
@@ -9,4 +9,87 @@ This feature blocks an IP address from making further attempts after a specified
 - Informs user about remaining retries or lockout time on login page.
 - Optional logging, optional email notification.
 
-To disable the ability to limit the number of login attempts, set the `modules.security.limit-login-attempts` setting to `false`.
+**Note:** In this document, we'll only show the `limit-login-attempts` configuration for brevity.
+
+To set the limit login attempts security settings, set values in your `composer.json` configuration under `extra.altis.modules.security.limit-login-attempts`. The default values are below, but all can be overriden.
+
+```json
+{
+	"extra": {
+		"altis": {
+			"modules": {
+				"security": {
+					"limit-login-attempts": {
+						"allowed_retries": 4,      // Lock out after this many tries.
+						"lockout_duration": 1200,  // Lock out for this many seconds - default to 20 minutes.
+						"allowed_lockouts": 4,     // Long lock out after this many lockouts.
+						"long_duration": 86400,    // Long lock out for this many seconds - defaults to 24 hours.
+						"valid_duration": 43200,   // Reset failed attempts after this many seconds - defaults to 12 hours.
+						"cookies": 1,              // Also limit malformed/forged cookies?
+						"lockout_notify": "log",   // Notify on lockout. Values: '', 'log', 'email', 'log,email'.
+						"notify_email_after": 4,   // If notify by email, do so after this number of lockouts.
+						"lockout_method": "ip"     // Method to use for lockout.
+					}
+				}
+			}
+		}
+	}
+}
+```
+## Configuration settings
+
+By setting the configuration settings in your `composer.json`, we lock the settings to those values and hide the admin settings page.
+
+### Allowed Retries
+
+Limit the number of retries a user has before we lock them out. Defaults to 4.
+
+### Lockout Duration
+
+The amount of time, in seconds, a user is locked out on normal lock outs. Defaults to 20 minutes - `1200`.
+
+### Allowed Lockouts
+
+Limit the number of lockouts a user has before we lock them out with a long lock out. Defaults to `4`.
+
+### Long Lockout Duration
+
+The amount of time, in seconds, a user is locked out on long lock outs. Defaults to 24 hours - `86400`.
+
+### Valid Duration
+
+The amount of time, in seconds, the system waits to reset the failed attempts. Defaults to 12 hours - `43200`.
+
+### Cookies
+
+Setting to determine if we should limit any malformed or forged cookies. Defaults to `true`.
+
+### Lockout Notify
+
+Setting to determine which method should be used to notify site admin about a lockout. Valid values are: empty for no notification, `log`, `email`, or `log,email`. Defaults to `log`.
+
+### Notify Email After
+
+If `lockout_notify` set to either `email` or `log,email`, this setting is used to determine after how many lockouts the admin should notified via email. Defaults to `4`.
+
+### Lockout Method
+
+Setting to determine which method should be used to lock users out. Valid values are: `ip`, `username`, or `ip,username`. Defaults to `ip`.
+
+## Enable/Disable
+
+You can also disable the functionality altogether by setting `limit-login-attempts` to `false`:
+
+```json
+{
+	"limit-login-attempts": false
+}
+```
+
+If `true` provided instead of a configuration object, then the plugin will use the same defaults but are able to be overridden via the settings page in the admin under `Settings -> Limit Logins`.
+
+```json
+{
+	"limit-login-attempts": true
+}
+```

--- a/inc/limit_login_attempts/namespace.php
+++ b/inc/limit_login_attempts/namespace.php
@@ -24,7 +24,7 @@ function bootstrap() {
 
 		// Set pre_option filters on each config item.
 		foreach ( $config as $option_name => $option_value ) {
-			
+
 			// Only options that are not integers are `lockout_notify` and `lockout_method`.
 			if ( ! in_array( $option_name, [ 'lockout_notify', 'lockout_method' ], true ) ) {
 				$option_value = intval( $option_value );

--- a/inc/limit_login_attempts/namespace.php
+++ b/inc/limit_login_attempts/namespace.php
@@ -3,6 +3,7 @@
 namespace Altis\Security\Limit_Login_Attempts;
 
 use const Altis\ROOT_DIR;
+use function Altis\get_config;
 
 /**
  * Bootstrap.
@@ -11,6 +12,25 @@ function bootstrap() {
 	// Set default constants for Altis.
 	define( 'HM_LIMIT_LOGIN_DIRECT_ADDR', 'HTTP_X_FORWARDED_FOR' );
 
+	$config = get_config()['modules']['security']['limit-login-attempts'];
+
 	// Load plugin.
 	require_once ROOT_DIR . '/vendor/humanmade/hm-limit-login-attempts/hm-limit-login-attempts.php';
+
+	// If config is just `true`, enable plugin and show admin page.
+	if ( is_array( $config ) ) {
+		// Otherwise, don't display admin page and use config values.
+		add_action( 'admin_menu', __NAMESPACE__ . '\\remove_admin_page', 99 );
+
+		// Set pre_option filters on each config item.
+		foreach ( $config as $option_name => $option_value ) {
+			add_filter( 'pre_option_hm_limit_login_' . $option_name, function() {
+				return $option_value;
+			} );
+		}
+	}
+}
+
+function remove_admin_page() {
+	remove_submenu_page( 'options-general.php', 'hm-limit-login-attempts' );
 }

--- a/inc/limit_login_attempts/namespace.php
+++ b/inc/limit_login_attempts/namespace.php
@@ -24,7 +24,7 @@ function bootstrap() {
 
 		// Set pre_option filters on each config item.
 		foreach ( $config as $option_name => $option_value ) {
-			add_filter( 'pre_option_hm_limit_login_' . $option_name, function() {
+			add_filter( 'pre_option_hm_limit_login_' . $option_name, function () {
 				return $option_value;
 			} );
 		}

--- a/inc/limit_login_attempts/namespace.php
+++ b/inc/limit_login_attempts/namespace.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Altis\Security\Limit_Login_Attempts;
+
+use const Altis\ROOT_DIR;
+
+/**
+ * Bootstrap.
+ */
+function bootstrap() {
+	// Set default constants for Altis.
+	define( 'HM_LIMIT_LOGIN_DIRECT_ADDR', 'HTTP_X_FORWARDED_FOR' );
+
+	// Load plugin.
+	require_once ROOT_DIR . '/vendor/humanmade/hm-limit-login-attempts/hm-limit-login-attempts.php';
+}

--- a/inc/limit_login_attempts/namespace.php
+++ b/inc/limit_login_attempts/namespace.php
@@ -24,6 +24,12 @@ function bootstrap() {
 
 		// Set pre_option filters on each config item.
 		foreach ( $config as $option_name => $option_value ) {
+			
+			// Only options that are not integers are `lockout_notify` and `lockout_method`.
+			if ( ! in_array( $option_name, [ 'lockout_notify', 'lockout_method' ], true ) ) {
+				$option_value = intval( $option_value );
+			}
+
 			add_filter( 'pre_option_hm_limit_login_' . $option_name, function () use ( $option_value ) {
 				return $option_value;
 			} );

--- a/inc/limit_login_attempts/namespace.php
+++ b/inc/limit_login_attempts/namespace.php
@@ -24,7 +24,7 @@ function bootstrap() {
 
 		// Set pre_option filters on each config item.
 		foreach ( $config as $option_name => $option_value ) {
-			add_filter( 'pre_option_hm_limit_login_' . $option_name, function () {
+			add_filter( 'pre_option_hm_limit_login_' . $option_name, function () use ( $option_value ) {
 				return $option_value;
 			} );
 		}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -4,7 +4,6 @@ namespace Altis\Security;
 
 use const Altis\ROOT_DIR;
 use function Altis\get_config;
-use function Altis\get_environment_type;
 
 function bootstrap() {
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\\on_plugins_loaded', 1 );
@@ -31,6 +30,10 @@ function on_plugins_loaded() {
 
 	if ( ! empty( $config['minimum-password-strength'] ) && $config['minimum-password-strength'] > 0 ) {
 		Passwords\bootstrap();
+	}
+
+	if ( $config['limit-login-attempts'] ) {
+		Limit_Login_Attempts\bootstrap();
 	}
 }
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -38,7 +38,7 @@ function on_plugins_loaded() {
 		Passwords\bootstrap();
 	}
 
-	if ( $config['limit-login-attempts'] ) {
+	if ( ! empty( $config['limit-login-attempts'] ) ) {
 		Limit_Login_Attempts\bootstrap();
 	}
 }

--- a/load.php
+++ b/load.php
@@ -20,7 +20,7 @@ add_action( 'altis.modules.init', function () {
 			'cookies'             => 1,       // Also limit malformed/forged cookies?
 			'lockout_notify'      => 'log',   // Notify on lockout. Values: '', 'log', 'email', 'log,email'.
 			'notify_email_after'  => 4,       // If notify by email, do so after this number of lockouts.
-			'lockout_method'      => 'ip'     // Method to use for lockout.
+			'lockout_method'      => 'ip',    // Method to use for lockout.
 		],
 		'browser' => [
 			'automatic-integrity' => true,

--- a/load.php
+++ b/load.php
@@ -11,7 +11,17 @@ add_action( 'altis.modules.init', function () {
 		'audit-log'                 => true,
 		'2-factor-authentication'   => true,
 		'minimum-password-strength' => 2,
-		'limit-login-attempts'      => true,
+		'limit-login-attempts'      => [
+			'allowed_retries'     => 4,       // Lock out after this many tries.
+			'lockout_duration'    => 1200,    // Lock out for this many seconds - default to 20 minutes.
+			'allowed_lockouts'    => 4,       // Long lock out after this many lockouts.
+			'long_duration'       => 86400,   // Long lock out for this many seconds - defaults to 24 hours.
+			'valid_duration'      => 43200,   // Reset failed attempts after this many seconds - defaults to 12 hours.
+			'cookies'             => 1,       // Also limit malformed/forged cookies?
+			'lockout_notify'      => 'log',   // Notify on lockout. Values: '', 'log', 'email', 'log,email'.
+			'notify_email_after'  => 4,       // If notify by email, do so after this number of lockouts.
+			'lockout_method'      => 'ip'     // Method to use for lockout.
+		],
 		'browser' => [
 			'automatic-integrity' => true,
 			'content-security-policy' => [

--- a/load.php
+++ b/load.php
@@ -21,6 +21,7 @@ add_action( 'altis.modules.init', function () {
 			'lockout_notify'      => 'log',   // Notify on lockout. Values: '', 'log', 'email', 'log,email'.
 			'notify_email_after'  => 4,       // If notify by email, do so after this number of lockouts.
 			'lockout_method'      => 'ip',    // Method to use for lockout.
+			'whitelisted_ips'     => [],      // Array of IP addresses to whitelist.
 		],
 		'browser' => [
 			'automatic-integrity' => true,

--- a/load.php
+++ b/load.php
@@ -11,6 +11,7 @@ add_action( 'altis.modules.init', function () {
 		'audit-log'                 => true,
 		'2-factor-authentication'   => true,
 		'minimum-password-strength' => 2,
+		'limit-login-attempts'      => true,
 	];
 	register_module( 'security', __DIR__, 'Security', $default_settings, __NAMESPACE__ . '\\bootstrap' );
 } );


### PR DESCRIPTION
This adds the HM Limit Login Attempts plugin per https://github.com/humanmade/altis-security/issues/28

This requires this PR to be merged for this to work properly: https://github.com/humanmade/hm-limit-login-attempts/pull/8

Additionally, `humanmade/hm-limit-login-attempts` would need to be published to packagist to remove the repository in the `composer.json`, but I do not have access to publish things on behalf of the organization.

Fixes #28 