### PR TITLE
add php-basic-auth package to required packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 		"bjeavons/zxcvbn-php": "^0.4.0",
 		"altis/browser-security": "^1.0.0",
 		"humanmade/hm-limit-login-attempts": "1.1.0",
+		"humanmade/php-basic-auth": "^1.1.0"
 		"humanmade/require-login": "1.0.1",
 		"humanmade/stream": "3.3.0",
 		"humanmade/two-factor": "0.2"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"bjeavons/zxcvbn-php": "^0.4.0",
 		"altis/browser-security": "^1.0.0",
 		"humanmade/hm-limit-login-attempts": "1.1.0",
-		"humanmade/php-basic-auth": "^1.1.0"
+		"humanmade/php-basic-auth": "^1.1.0",
 		"humanmade/require-login": "1.0.1",
 		"humanmade/stream": "3.3.0",
 		"humanmade/two-factor": "0.2"


### PR DESCRIPTION
Adds `humanmade/php-basic-auth` back to the main `composer.json` file.
fixes #50 