### PR TITLE
[Backport v3-branch] Re-enable require-login by default in non-production environments

### DIFF
--- a/docs/require-login.md
+++ b/docs/require-login.md
@@ -2,6 +2,8 @@
 
 By default, all websites are publicly accessible. In some situations, you may want to require users to be logged in to access the website. This is especially useful when in pre-launch mode.
 
+Environments running in Cloud that are not of type `production` have the `require-login` feature enabled by default.
+
 ## Controlling Site Access
 
 Requiring login on individual sites is as easy as unchecking the site's public setting in the Edit Site screen. To access this setting, go to [My Sites > Network Admin > Sites](internal://network-admin/sites.php) and then click the URL for the site you want to edit. From there you check the box for whether the site is public or not under the "Attributes" section.

--- a/load.php
+++ b/load.php
@@ -2,12 +2,13 @@
 
 namespace Altis\Security; // @codingStandardsIgnoreLine
 
+use Altis;
 use function Altis\register_module;
 
 add_action( 'altis.modules.init', function () {
 	$default_settings = [
 		'enabled'                   => true,
-		'require-login'             => false,
+		'require-login'             => ! in_array( Altis\get_environment_type(), [ 'production', 'local' ], true ),
 		'audit-log'                 => true,
 		'2-factor-authentication'   => true,
 		'minimum-password-strength' => 2,


### PR DESCRIPTION
Backporting #60

---------------------

Introduced by #33, we added support for the site's public setting in the Network admin. In doing so, we also removed the environment type default in require login. This was an oversight, where we still want that default, but also want support for site-specific settings. For non-production environments, teams should specifically disable the require-login feature on staging / dev sites if they want to _really_ make sites public.