### PR TITLE
Fix array access warning

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -109,7 +109,7 @@ function remove_2fa_dummy_provider( array $providers ) : array {
  */
 function override_two_factor_universally_forced( bool $is_forced ) : bool {
 	$config = Altis\get_config()['modules']['security']['2-factor-authentication'];
-	if ( ! empty( $config['required'] ) || is_bool( $config['required'] ) ) {
+	if ( is_array( $config ) && ( ! empty( $config['required'] ) || is_bool( $config['required'] ) ) ) {
 		return $config['required'];
 	}
 

--- a/inc/stream/namespace.php
+++ b/inc/stream/namespace.php
@@ -54,6 +54,8 @@ function default_stream_network_options( array $options ) : array {
  */
 function remove_stream_admin_pages() {
 	/**
+	 * Stream plugin instance.
+	 *
 	 * @var \Stream\Plugin
 	 */
 	global $wp_stream;


### PR DESCRIPTION
The `empty()` will now emit a warning if trying to access a non existent array index if the type is not an array. Happens in PHP 7.4.