### PR TITLE
switch to official stream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
 		"altis/browser-security": "^1.0.0",
 		"humanmade/php-basic-auth": "^1.1.0",
 		"humanmade/require-login": "~1.0.2",
-		"humanmade/stream": "3.4.2",
-		"humanmade/two-factor": "0.2"
+		"humanmade/two-factor": "0.2",
+		"xwp/stream": "^3.6.2"
 	},
 	"extra": {
 		"altis": {
@@ -35,8 +35,8 @@
 				"altis/browser-security",
 				"humanmade/php-basic-auth",
 				"humanmade/require-login",
-				"humanmade/stream",
-				"humanmade/two-factor"
+				"humanmade/two-factor",
+				"xwp/stream"
 			]
 		}
 	}

--- a/inc/stream/namespace.php
+++ b/inc/stream/namespace.php
@@ -34,7 +34,11 @@ function bootstrap() {
 	add_action( 'network_admin_menu', __NAMESPACE__ . '\\remove_stream_admin_pages', 11 );
 	add_action( 'admin_bar_menu', __NAMESPACE__ . '\\override_network_admin_bar_menu', 100 );
 	add_filter( 'wp_stream_record_array', __NAMESPACE__ . '\\filter_wp_stream_record_array', 10, 1 );
-	require_once Altis\ROOT_DIR . '/vendor/humanmade/stream/stream.php';
+
+	// We don't get the minified versions of the assets from the Composer package, so we need to use the full versions.
+	add_filter( 'wp_stream_load_min_assets', '__return_false' );
+
+	require_once Altis\ROOT_DIR . '/vendor/xwp/stream/stream.php';
 }
 
 /**

--- a/inc/stream/namespace.php
+++ b/inc/stream/namespace.php
@@ -34,10 +34,6 @@ function bootstrap() {
 	add_action( 'network_admin_menu', __NAMESPACE__ . '\\remove_stream_admin_pages', 11 );
 	add_action( 'admin_bar_menu', __NAMESPACE__ . '\\override_network_admin_bar_menu', 100 );
 	add_filter( 'wp_stream_record_array', __NAMESPACE__ . '\\filter_wp_stream_record_array', 10, 1 );
-
-	// We don't get the minified versions of the assets from the Composer package, so we need to use the full versions.
-	add_filter( 'wp_stream_load_min_assets', '__return_false' );
-
 	require_once Altis\ROOT_DIR . '/vendor/xwp/stream/stream.php';
 }
 


### PR DESCRIPTION
This pr swaps out our Stream fork for the official package. 

~The official package does not include minified files, so we have to hijack the function that determines whether `.min` should be added to the path to all the JS and CSS assets, but this may be something we can fix upstream as well.~ (this issue is fixed)

I thought that there was an issue where only one site's data was being reported, but that turned out to be a red herring.

Opened a ticket in their repository for the above issue: https://github.com/xwp/stream/issues/1255

Fixes #58 