### PR TITLE
Warn user more clearly when their password is not accepted

### DIFF
--- a/inc/passwords/namespace.php
+++ b/inc/passwords/namespace.php
@@ -18,6 +18,8 @@ function bootstrap() {
 	add_action( 'check_passwords', __NAMESPACE__ . '\\enforce_password_strength', 10, 3 );
 	add_action( 'admin_print_styles-user-edit.php', __NAMESPACE__ . '\\hide_weak_password_prompt' );
 	add_action( 'admin_print_styles-profile.php', __NAMESPACE__ . '\\hide_weak_password_prompt' );
+	add_action( 'edit_user_profile', __NAMESPACE__ . '\\show_weak_password_prompt', 100 );
+	add_action( 'show_user_profile', __NAMESPACE__ . '\\show_weak_password_prompt', 100 );
 }
 
 /**
@@ -129,5 +131,31 @@ function hide_weak_password_prompt() {
 		return;
 	}
 
-	echo '<style>.pw-weak { display: none !important; }</style>';
+	echo '<style>tr.pw-weak { display: none !important; }</style>';
+}
+
+/**
+ * Show an error message to the user before the submit button.
+ */
+function show_weak_password_prompt(){?>
+
+	<div class="pw-weak">
+		<p>
+			<strong><?php esc_html_e( 'ERROR', 'altis' );?></strong><?php esc_html_e( ': Please use a stronger ', 'altis' );?><a href="#password"><?php esc_html_e( 'password', 'altis' );?></a>.
+		</p>
+	</div>
+
+	<style>
+		.pw-weak{
+			background: #fff;
+			border: 1px solid #c3c4c7;
+			border-left-width: 4px;
+			border-left-color: #d63638;
+			box-shadow: 0 1px 1px rgb(0 0 0 / 4%);
+			margin: 0.5em 0;
+			padding: 1px 12px;
+		}
+		
+	</style>
+	<?php
 }

--- a/inc/passwords/namespace.php
+++ b/inc/passwords/namespace.php
@@ -141,7 +141,7 @@ function show_weak_password_prompt(){?>
 
 	<div class="pw-weak">
 		<p>
-			<strong><?php esc_html_e( 'ERROR', 'altis' );?></strong><?php esc_html_e( ': Please use a stronger ', 'altis' );?><a href="#password"><?php esc_html_e( 'password', 'altis' );?></a>.
+			<strong><?php esc_html_e( 'ERROR', 'altis' ); ?></strong><?php esc_html_e( ': Please use a stronger ', 'altis' ); ?><a href="#password"><?php esc_html_e( 'password', 'altis' ); ?></a>.
 		</p>
 	</div>
 
@@ -155,7 +155,6 @@ function show_weak_password_prompt(){?>
 			margin: 0.5em 0;
 			padding: 1px 12px;
 		}
-		
 	</style>
 	<?php
 }


### PR DESCRIPTION
( updated details from [Shadi's comment](https://github.com/humanmade/altis-security/pull/137#issuecomment-957303804) )
### Description
When changing a users password and it is not strong enough, the submit button on the profile page is disabled. The default functionality is hidden with CSS.

### Development changes
Previously the css class `pw-weak` was set to be hidden. I have changed it to target the `tr.pw-weak` so it only hides the checkbox which was originally being hidden. This has allowed the ability to re-use the class for the error message to be displayed.

### Error message display
This is the error message displayed when you have entered a weak password and now wanting to submit the change.
![Screenshot 2021-11-02 at 14 01 16](https://user-images.githubusercontent.com/16571365/139842739-aea4f819-79ed-4962-816e-ed02862f8920.png)

### Steps for testing
1. Log into the wp-admin area
2. Either navigate to edit your profile from the top right corner or navigate to users and select a user you wish to edit.
3. **Set New Password** to something **Very weak**
4. Scroll down to **Update User**, where you should see the error message, with a link that will scroll you back to the password section.
5. Changing to a stronger password will hide the error message and allow you up click **Update User** and change the password.
