### PR TITLE
Add HSTS header support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	"require": {
 		"php": ">=7.1",
 		"bjeavons/zxcvbn-php": "^1.1.0",
-		"altis/browser-security": "^1.1.1",
+		"altis/browser-security": "^1.2.0",
 		"humanmade/disable-accounts": "^0.2.1",
 		"humanmade/php-basic-auth": "^1.1.6",
 		"humanmade/require-login": "~1.0.4",

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -177,6 +177,23 @@ Altis automatically adds various miscellaneous security headers by default. Thes
 In some cases, you may want to adjust or disable these headers depending on the use cases of your site.
 
 
+#### Strict-Transport-Security
+
+The [`Strict-Transport-Security` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) (sometimes called HSTS) is used to enforce HTTPS (TLS/SSL) connections when loading a site and can be used to enhance the site's security.
+
+By default, Altis does not enable HSTS. You can set the value of this header manually by defining the `ABS_HSTS` constant:
+
+```php
+define( 'ABS_HSTS', 'max-age=31536000; includeSubDomains' );
+```
+
+To disable the automatic behaviour entirely, set the constant to `false`:
+
+```php
+define( 'ABS_HSTS', false );
+```
+
+
 #### X-Content-Type-Options
 
 By default, Altis adds a [`X-Content-Type-Options` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options) with the value set to `nosniff`. This prevents browsers from attempting to guess the content type based on the content, and instead forces them to follow the type set in the `Content-Type` header.

--- a/load.php
+++ b/load.php
@@ -35,6 +35,7 @@ add_action( 'altis.modules.init', function () {
 			],
 			'frame-options-header' => true,
 			'nosniff-header' => true,
+			'strict-transport-security' => false,
 			'xss-protection-header' => true,
 		],
 	];


### PR DESCRIPTION
Adds the ability to set HSTS headers via altis/browser-security

I'm only backporting this to the current version. Will also file a follow-up for changing the default in v11.