### PR TITLE
Bump altis/browser-security to 2.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	"require": {
 		"php": ">=7.1",
 		"bjeavons/zxcvbn-php": "^1.1.0",
-		"altis/browser-security": "^2.0.0",
+		"altis/browser-security": "^2.0.1",
 		"humanmade/disable-accounts": "^0.2.1",
 		"humanmade/php-basic-auth": "^1.1.7",
 		"humanmade/require-login": "~1.0.5",


### PR DESCRIPTION
Adds the correct header name for HSTS fix. See:

* https://github.com/humanmade/altis-browser-security/pull/20#issuecomment-1446512934