### PR TITLE
Fix config key check for force enabling PHP Basic Auth

### DIFF
--- a/inc/php_basic_auth/namespace.php
+++ b/inc/php_basic_auth/namespace.php
@@ -50,7 +50,7 @@ function define_credentials() {
  */
 function force_enable( $should_enable ) {
 	$environment = Altis\get_environment_type();
-	$env_config = Altis\get_config()['environments'][ $environment ]['modules']['security']['basic-auth'] ?? [];
+	$env_config = Altis\get_config()['environments'][ $environment ]['modules']['security']['php-basic-auth'] ?? [];
 
 	// If there's no config, use the existing values.
 	if ( empty( $env_config ) || ! is_array( $env_config ) ) {


### PR DESCRIPTION
The config key being checked was incorrect, so even with setting `php-basic-auth` to `true` in your config it wouldn't load the plugin as documented.