### PR TITLE
Updated two-factor dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"humanmade/disable-accounts": "^0.2.2",
 		"humanmade/php-basic-auth": "^1.1.7",
 		"humanmade/require-login": "~1.0.5",
-		"humanmade/two-factor": "^0.3.0",
+		"humanmade/two-factor": "^0.3.3",
 		"xwp/stream": "^3.9.3"
 	},
 	"extra": {


### PR DESCRIPTION
Merges upstream version as at [0.8.1](https://github.com/WordPress/two-factor/releases/tag/0.8.1)
Adds require the external `qrcode` library, as there is no build step with composer.
