### PR TITLE
Revert "Update humanmade/two-factor requirement from ^0.3.3 to ^0.6.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"humanmade/disable-accounts": "^0.2.2",
 		"humanmade/php-basic-auth": "^1.1.7",
 		"humanmade/require-login": "~1.0.5",
-		"humanmade/two-factor": "^0.6.0",
+		"humanmade/two-factor": "^0.3.3",
 		"xwp/stream": "^3.10.0"
 	},
 	"extra": {


### PR DESCRIPTION
Reverts humanmade/altis-security#331

This uses the upstream version tag instead of our version tag on the `force-2fa` branch