### PR TITLE
Allow disabling 2FA in config

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -136,7 +136,7 @@ function override_two_factor_forced_user_roles( $roles ) {
 		return [];
 	}
 
-	if ( ! empty( $config['required'] ) && is_array( $config['required'] ) ) {
+	if ( is_array( $config['required'] ) ) {
 		return $config['required'];
 	}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -131,6 +131,11 @@ function override_two_factor_universally_forced( bool $is_forced ) : bool {
  */
 function override_two_factor_forced_user_roles( $roles ) {
 	$config = Altis\get_config()['modules']['security']['2-factor-authentication'];
+
+	if ( isset( $config['required'] ) && $config['required'] === false ) {
+		return [];
+	}
+
 	if ( ! empty( $config['required'] ) && is_array( $config['required'] ) ) {
 		return $config['required'];
 	}


### PR DESCRIPTION
I'd like to be able to easily disable 2 Factor Auth on my local environment but i'm finding this a little tricky to do so. 

I have enabled 2-factor-authentication in my config forcing it to be enabled for certain roles, as per the documentation. But for my local environment I'm overriding this and I'd expect that setting required to false or an empty array would disable this. However it does not. The filter only overrides the forced user roles if it is set to an array that is not empty. 

```
{
	"altis": {
		"modules": {
			"security": {
				"2-factor-authentication": {
					"required": [
						"super-admin",
						"administrator"
					]
				}
			}
		},
		"environments": {
			"local": {
				"modules": {
					"security": {
						"2-factor-authentication": {
							"required": false
						}
					}
				}
			}
		}
	}
}
```

Note that the value of the site option `_two_factor_forced_user_roles` in the database is `[ 'administrator' ]` and deleting this option does work to disable, however I'd expect the Altis config to override this. 

One hack/workaround I can use now is define the array of roles as something like `[ "none" ]` but this isn't great. The proposed fix is to ensure the Altis filter returns an empty array if the config is set to false or an empty array.