### PR TITLE
Fix PHP warning for empty security module settings

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -136,7 +136,7 @@ function override_two_factor_forced_user_roles( $roles ) {
 		return [];
 	}
 
-	if ( is_array( $config['required'] ) ) {
+	if ( isset( $config['required'] ) && is_array( $config['required'] ) ) {
 		return $config['required'];
 	}
 


### PR DESCRIPTION
Since PR https://github.com/humanmade/altis-security/pull/374 I've noticed a PHP warning in the logs:
```
PHP Warning:  Trying to access array offset on value of type bool in /usr/src/app/packages/security/inc/namespace.php on line 139
```

This is because the `required` key in the `override_two_factor_forced_user_roles` function is not always an array or even present. For example, if your relevant section of `composer.json` looks like this:
```	json
{
	"extra": {
		"altis": {
			"modules": {
				"security": {}
			}
		}
	}
}
```
you get the warning.

This PR adds a check to ensure that the key is an array before trying to access it.

Testing functionality with no 'required' setting and with a list of roles both continue to work as they should without the warning.
