### PR TITLE
Update Stream dependency to 4.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"bjeavons/zxcvbn-php": "^1.4.2",
 		"altis/browser-security": "^2.1.0",
 		"humanmade/disable-accounts": "^0.2.2",
-		"humanmade/php-basic-auth": "^1.1.7",
+		"humanmade/php-basic-auth": "dev-20251120-update-dependencies",
 		"humanmade/require-login": "~1.0.5",
 		"humanmade/two-factor": "^0.3.3",
 		"xwp/stream": "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		"humanmade/php-basic-auth": "^1.1.7",
 		"humanmade/require-login": "~1.0.5",
 		"humanmade/two-factor": "^0.3.3",
-		"xwp/stream": "^4.0.2"
+		"xwp/stream": "dev-master"
 	},
 	"extra": {
 		"altis": {

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
 		"bjeavons/zxcvbn-php": "^1.4.2",
 		"altis/browser-security": "^2.1.0",
 		"humanmade/disable-accounts": "^0.2.2",
-		"humanmade/php-basic-auth": "dev-20251120-update-dependencies",
+		"humanmade/php-basic-auth": "^1.1.7",
 		"humanmade/require-login": "~1.0.5",
 		"humanmade/two-factor": "^0.3.3",
-		"xwp/stream": "dev-master"
+		"xwp/stream": "^4.1.2"
 	},
 	"extra": {
 		"altis": {

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -46,3 +46,23 @@ detailed documentation on [creating custom Connectors](https://github.com/xwp/st
 Stream plugin documentation.
 
 Once registered, your custom Stream Connector's records will be part of the Audit Log with the same data integrity guarantees.
+
+## Action Scheduler
+
+The Audit Log plugin (Stream) bundles [Action Scheduler](https://actionscheduler.org/) as a dependency. By default, Altis disables the Action Scheduler queue runner cron event (`action_scheduler_run_queue`) since it is not needed for core audit logging functionality.
+
+If another plugin in your project requires Action Scheduler's queue processing, you can re-enable it in your Altis configuration:
+
+```json
+{
+	"extra": {
+		"altis": {
+			"modules": {
+				"security": {
+					"disable-action-scheduler-cron": false
+				}
+			}
+		}
+	}
+}
+```

--- a/inc/stream/namespace.php
+++ b/inc/stream/namespace.php
@@ -41,6 +41,11 @@ function bootstrap() {
 	add_action( 'network_admin_menu', __NAMESPACE__ . '\\remove_stream_admin_pages', 11 );
 	add_action( 'admin_bar_menu', __NAMESPACE__ . '\\override_network_admin_bar_menu', 100 );
 	add_filter( 'wp_stream_record_array', __NAMESPACE__ . '\\filter_wp_stream_record_array', 10, 1 );
+
+	// Initialise Action Scheduler first so Stream can initialise.
+	require_once Altis\ROOT_DIR . '/vendor/xwp/stream/vendor/woocommerce/action-scheduler/action-scheduler.php';
+	action_scheduler_register_3_dot_8_dot_1();
+	action_scheduler_initialize_3_dot_8_dot_1();
 	require_once Altis\ROOT_DIR . '/vendor/xwp/stream/stream.php';
 }
 

--- a/inc/stream/namespace.php
+++ b/inc/stream/namespace.php
@@ -39,6 +39,7 @@ function bootstrap() {
 	add_filter( 'site_option_wp_stream_network', __NAMESPACE__ . '\\default_stream_network_options' );
 	add_filter( 'default_site_option_wp_stream_network', __NAMESPACE__ . '\\default_stream_network_options' );
 	add_action( 'network_admin_menu', __NAMESPACE__ . '\\remove_stream_admin_pages', 11 );
+	add_action( 'admin_menu', __NAMESPACE__ . '\\remove_action_scheduler_menu', 11 );
 	add_action( 'admin_bar_menu', __NAMESPACE__ . '\\override_network_admin_bar_menu', 100 );
 	add_filter( 'wp_stream_record_array', __NAMESPACE__ . '\\filter_wp_stream_record_array', 10, 1 );
 
@@ -86,6 +87,13 @@ function remove_stream_admin_pages() {
 	 */
 	global $wp_stream;
 	remove_submenu_page( $wp_stream->admin->records_page_slug, $wp_stream->admin->network->network_settings_page_slug );
+}
+
+/**
+ * Remove the Action Scheduler admin page.
+ */
+function remove_action_scheduler_menu() {
+	remove_submenu_page( 'tools.php', 'action-scheduler' );
 }
 
 /**

--- a/inc/stream/namespace.php
+++ b/inc/stream/namespace.php
@@ -43,10 +43,38 @@ function bootstrap() {
 	add_action( 'admin_bar_menu', __NAMESPACE__ . '\\override_network_admin_bar_menu', 100 );
 	add_filter( 'wp_stream_record_array', __NAMESPACE__ . '\\filter_wp_stream_record_array', 10, 1 );
 
-	// Initialise Action Scheduler first so Stream can initialise.
+	// Initialise Action Scheduler so Stream can use its API functions (e.g. as_enqueue_async_action).
+	// Requiring action-scheduler.php adds hooks on plugins_loaded at priority 0,
+	// but we're already past that, so we must manually trigger registration and initialization.
+	// The register function name includes the version number (e.g. action_scheduler_register_3_dot_9_dot_3)
+	// and changes with each release, so we find it dynamically to avoid breakage on updates.
 	require_once Altis\ROOT_DIR . '/vendor/xwp/stream/vendor/woocommerce/action-scheduler/action-scheduler.php';
-	action_scheduler_register_3_dot_8_dot_1();
-	action_scheduler_initialize_3_dot_8_dot_1();
+	$as_versions = \ActionScheduler_Versions::instance();
+	if ( ! $as_versions->latest_version() ) {
+		foreach ( get_defined_functions()['user'] as $func ) {
+			if ( strpos( $func, 'action_scheduler_register_' ) === 0 ) {
+				call_user_func( $func );
+				break;
+			}
+		}
+	}
+	\ActionScheduler_Versions::initialize_latest_version();
+
+	// Disable the Action Scheduler queue runner cron event unless another plugin needs it.
+	// AS is only needed here for Stream's API functions, not for processing queued actions.
+	$config = Altis\get_config()['modules']['security'];
+	if ( $config['disable-action-scheduler-cron'] ?? true ) {
+		add_action( 'init', function () {
+			if ( class_exists( 'ActionScheduler', false ) ) {
+				remove_action( 'init', [ \ActionScheduler::runner(), 'init' ], 1 );
+				$timestamp = wp_next_scheduled( 'action_scheduler_run_queue', [ 'WP Cron' ] );
+				if ( $timestamp ) {
+					wp_unschedule_event( $timestamp, 'action_scheduler_run_queue', [ 'WP Cron' ] );
+				}
+			}
+		}, 0 );
+	}
+
 	require_once Altis\ROOT_DIR . '/vendor/xwp/stream/stream.php';
 }
 

--- a/load.php
+++ b/load.php
@@ -15,6 +15,7 @@ add_action( 'altis.modules.init', function () {
 		'require-login'             => ! in_array( Altis\get_environment_type(), [ 'production', 'local' ], true ),
 		'php-basic-auth'            => false,
 		'audit-log'                 => true,
+		'disable-action-scheduler-cron' => true,
 		'disable-accounts'          => true,
 		'2-factor-authentication'   => Altis\get_environment_type() === 'local' ? true : [
 			'required' => [


### PR DESCRIPTION
- Change xwp/stream from ^4.0.2 to 4.1.1 in composer.json
- Add Action Scheduler initialization before loading Stream plugin
- Ensures Action Scheduler is properly registered before Stream initialization

~~Note: This temporarily uses `dev-master` for xwp/stream until the 4.1.1 tag is available.~~
Version 4.1.2 is now available

- Addresses: https://github.com/humanmade/product-dev/issues/1723