### PR TITLE
Fix failing audit tests.

### DIFF
--- a/tests/acceptance/AuditLogCest.php
+++ b/tests/acceptance/AuditLogCest.php
@@ -31,6 +31,10 @@ class AuditLogCest {
 		$I->click( '.editor-post-title__input' );
 		$I->type( 'Test audit log' );
 
+		// Close the settings sidebar if open (it can overlap the publish button).
+		$I->executeJS( "document.querySelector('button[aria-label=\"Close Settings\"]')?.click();" );
+		$I->wait( 0.5 );
+
 		// Publish the post.
 		$I->click( '.editor-post-publish-button__button' );
 		$I->click( '.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button' );


### PR DESCRIPTION
The tests were failing because the settings sidebar was open and overlapping the publish button, preventing it from being clicked.

This change adds a step to close the settings sidebar before attempting to publish the post, ensuring that the publish button is accessible.

Once the post is published, the test verifies that the audit log correctly records the creation of the new post.

- Fixes https://github.com/humanmade/altis-security/issues/375