### PR TITLE
Switch into editor-canvas iframe before clicking post title

### DIFF
--- a/tests/acceptance/AuditLogCest.php
+++ b/tests/acceptance/AuditLogCest.php
@@ -27,9 +27,15 @@ class AuditLogCest {
 		// Go to new post page.
 		$I->amOnAdminPage( 'post-new.php' );
 
-		// Add a title.
+		// The block editor canvas is iframed since WP 6.3 — the title input
+		// lives inside the `editor-canvas` iframe and is unreachable from the
+		// main frame.
+		$I->waitForElement( 'iframe[name="editor-canvas"]', 10 );
+		$I->switchToIFrame( 'editor-canvas' );
+		$I->waitForElement( '.editor-post-title__input', 10 );
 		$I->click( '.editor-post-title__input' );
 		$I->type( 'Test audit log' );
+		$I->switchToIFrame();
 
 		// Close the settings sidebar if open (it can overlap the publish button).
 		$I->executeJS( "document.querySelector('button[aria-label=\"Close Settings\"]')?.click();" );


### PR DESCRIPTION
## Summary
- `AuditLogCest::testCreatePostForAuditLog` was failing because `.editor-post-title__input` is now inside the iframed block editor canvas (`<iframe name="editor-canvas">`) introduced in WP 6.3.
- Switch the WebDriver frame context into the iframe to click the title, then switch back to the main frame for the publish flow.
- This also fixes the cascading `testConfirmActionsInAuditLog` failure (no post → no audit-log entry to find).

## Background
The block editor canvas became an iframe in WordPress 6.3. Codeception/WebDriver can't reach elements inside an iframe without first switching context, so `$I->click('.editor-post-title__input')` reported "element not found", the title was never entered, and the publish silently never happened. Caught by product-dev nightly CI ([run 25669000209](https://github.com/humanmade/product-dev/actions/runs/25669000209)).

## Test plan
- [x] `composer dev-tools codecept run -p vendor/altis/security/tests/ -- acceptance AuditLogCest` passes locally (both tests, 4 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)