### PR TITLE
Fix AuditLogCest for WP7 iframed block editor

### DIFF
--- a/tests/acceptance/AuditLogCest.php
+++ b/tests/acceptance/AuditLogCest.php
@@ -27,9 +27,15 @@ class AuditLogCest {
 		// Go to new post page.
 		$I->amOnAdminPage( 'post-new.php' );
 
-		// Add a title.
-		$I->click( '.editor-post-title__input' );
+		// Add a title. WP7 uses an iframed editor canvas so the title field is
+		// inside iframe[name="editor-canvas"] rather than the main document.
+		$I->waitForElement( 'iframe[name="editor-canvas"]', 30 );
+		$I->wait( 2 );
+		$I->switchToIframe( 'editor-canvas' );
+		$I->waitForElement( '[aria-label="Add title"], h1.wp-block-post-title', 10 );
+		$I->click( '[aria-label="Add title"], h1.wp-block-post-title' );
 		$I->type( 'Test audit log' );
+		$I->switchToIframe(); // back to main frame
 
 		// Close the settings sidebar if open (it can overlap the publish button).
 		$I->executeJS( "document.querySelector('button[aria-label=\"Close Settings\"]')?.click();" );


### PR DESCRIPTION
## Summary

- WP 7.0 renders the block editor inside `iframe[name="editor-canvas"]`. The title field no longer exists in the main document, so the previous `.editor-post-title__input` selector did nothing silently, leaving the post untitled and causing the audit log assertion to fail.
- Fix: switch into the editor iframe before typing the title, then switch back to the main frame for the publish button.

## Test plan

- [x] Run `composer dev-tools codecept run -p packages/security/tests -- acceptance AuditLogCest` against a WP 7.0 environment
- [x] Confirm `OK (2 tests, 4 assertions)`

Discovered during WP 7.0 QA (humanmade/product-dev#2127).