### PR TITLE
Update GHA reusable workflow ref to module-ci-v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   ci:
-    uses: humanmade/altis-dev-tools/.github/workflows/module-ci.yml@088bce7321fde60b9c22e792e764fa13ccd8f6ab
+    uses: humanmade/altis-dev-tools/.github/workflows/module-ci.yml@module-ci-v1
     with:
       altis-package: altis/security
     secrets:


### PR DESCRIPTION
Track module-ci-v1 moving tag